### PR TITLE
Add additional checks for non-empty repo file

### DIFF
--- a/templates/git-update-hook.erb
+++ b/templates/git-update-hook.erb
@@ -35,6 +35,19 @@ case "$refname" in
             echo "Creating new checkout for branch $branch_name..."
             mkdir -p $newrev_path
             GIT_WORK_TREE=$newrev_path git checkout --force --quiet $newrev
+            
+            if [ ! -f "$checkouts_dir/master/README.md" ]
+            then
+                echo "Sanity check file does not exist..." >&2
+                exit 1
+            fi
+
+            if [ ! -s "$checkouts_dir/master/README.md" ]
+            then
+                echo "Empty sanity check file..." >&2
+                exit 1
+            fi
+            
             ln -nsf "$clean_branch_name.$newrev" "$clean_branch_path"
 
             if [ ! $oldrev = "0000000000000000000000000000000000000000" ]

--- a/templates/git-update-hook.erb
+++ b/templates/git-update-hook.erb
@@ -36,13 +36,13 @@ case "$refname" in
             mkdir -p $newrev_path
             GIT_WORK_TREE=$newrev_path git checkout --force --quiet $newrev
             
-            if [ ! -f "$checkouts_dir/master/README.md" ]
+            if [ ! -f "$newrev_path/README.md" ]
             then
                 echo "Sanity check file does not exist..." >&2
                 exit 1
             fi
 
-            if [ ! -s "$checkouts_dir/master/README.md" ]
+            if [ ! -s "$newrev_path/README.md" ]
             then
                 echo "Empty sanity check file..." >&2
                 exit 1


### PR DESCRIPTION
There can be cases where the repo is corrupt and files checked out will be empty, this checks a file that should exist and not be 0-bytes size.